### PR TITLE
Defined bootstrap file in phpunit config file to fix run tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,8 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php">
 
     <testsuites>
         <testsuite name="Test Suite">


### PR DESCRIPTION
Tests fail if you run phpunit without defining a bootstrap file due to class loading reasons.