### PR TITLE
Fixes the following AMQP connection error:

### DIFF
--- a/src/Lw/Infrastructure/Ui/Web/Silex/Application.php
+++ b/src/Lw/Infrastructure/Ui/Web/Silex/Application.php
@@ -24,7 +24,7 @@ use Lw\Infrastructure\Service\TranslatingUserService;
 use Silex\Provider\DoctrineServiceProvider;
 use Silex\Provider\MonologServiceProvider;
 use Silex\Provider;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPConnection;
 use Silex\Provider\TwigServiceProvider;
 
 class Application
@@ -72,7 +72,7 @@ class Application
 
         $app['message_producer'] = $app->share(function () {
             return new RabbitMqMessageProducer(
-                new AMQPStreamConnection('localhost', 5672, 'guest', 'guest')
+                new AMQPConnection('localhost', 5672, 'guest', 'guest')
             );
         });
 


### PR DESCRIPTION
`PHP Catchable fatal error:  Argument 1 passed to Ddd\Infrastructure\Application\Notification\RabbitMqMessaging::__construct() must be an instance of PhpAmqpLib\Connection\AMQPConnection, instance of PhpAmqpLib\Connection\AMQPStreamConnection given, called in /var/www/last-wishes/src/Lw/Infrastructure/Ui/Web/Silex/Application.php on line 76 and defined in /var/www/last-wishes/vendor/carlosbuenosvinos/ddd/src/Infrastructure/Application/Notification/RabbitMqMessaging.php on line 12`
